### PR TITLE
Feature / Comments migration & comments seeder

### DIFF
--- a/apps/laravel/app/database/migrations/2022_10_12_161822_create_comments_table.php
+++ b/apps/laravel/app/database/migrations/2022_10_12_161822_create_comments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCommentsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->bigInteger('post_id')->unsigned()->index();
+            $table->bigInteger('parent_id')->unsigned()->index()->nullable();
+            $table->string('name');
+            $table->string('message');
+            $table->timestamps();
+
+            $table->foreign('parent_id')->references('id')->on('comments');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+}

--- a/apps/laravel/app/database/seeders/DatabaseSeeder.php
+++ b/apps/laravel/app/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,6 +18,28 @@ class DatabaseSeeder extends Seeder
     }
 
     private function runCommentsTableSeeder() {
-        // TODO
+        // First root comment tree
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, null, 'andre', 'main message', '2022-10-12 00:00:00', '2022-10-12 00:00:00')"); // # 1 (main)
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 1, 'andre-sub', 'sub message 1', '2022-10-12 00:00:05', '2022-10-12 00:00:05')"); // # 2 (sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 1, 'andre-sub', 'sub message 2', '2022-10-12 00:00:10', '2022-10-12 00:00:10')"); // # 3 (sub)
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 2, 'andre-sub-sub', 'sub-sub message 1', '2022-10-12 00:00:15', '2022-10-12 00:00:15');"); // # 4 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 2, 'andre-sub-sub', 'sub-sub message 2', '2022-10-12 00:00:20', '2022-10-12 00:00:20');"); // # 5 (sub-sub)
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 3, 'andre-sub-sub', 'sub-sub message 3', '2022-10-12 00:00:25', '2022-10-12 00:00:25');"); // # 6 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 3, 'andre-sub-sub', 'sub-sub message 4', '2022-10-12 00:00:30', '2022-10-12 00:00:30');"); // # 7 (sub-sub)
+
+        // Second root comment tree
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, null, 'maxim', 'main message', '2022-10-12 00:00:32', '2022-10-12 00:00:32')"); // # 8 (main)
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 8, 'maxim-sub', 'sub message 1', '2022-10-12 00:00:35', '2022-10-12 00:00:35')"); // # 9 (sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 8, 'maxim-sub', 'sub message 2', '2022-10-12 00:00:40', '2022-10-12 00:00:40')"); // # 10 (sub)
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 9, 'maxim-sub-sub', 'sub-sub message 1', '2022-10-12 00:00:45', '2022-10-12 00:00:45');"); // # 11 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 9, 'maxim-sub-sub', 'sub-sub message 2', '2022-10-12 00:00:50', '2022-10-12 00:00:50');"); // # 12 (sub-sub)
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 10, 'maxim-sub-sub', 'sub-sub message 3', '2022-10-12 00:00:55', '2022-10-12 00:00:55');"); // # 13 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 10, 'maxim-sub-sub', 'sub-sub message 4', '2022-10-12 00:00:58', '2022-10-12 00:00:58');"); // # 14 (sub-sub)
     }
 }


### PR DESCRIPTION
## Description

Hi.

This PR brings up the necessary migration to create comments table, and also, it brings up the comments seeder.

## Commands

There's a folder in `laravel` folder called scripts, and inside that folder there's a file called `entrypoint.sh`. Just a heads up that entrypoint script runs a command to create the migrations and right after it runs a command to create seeders.

## Screenshots

![image](https://user-images.githubusercontent.com/43224250/195431788-a322f97a-2731-44fc-b2a0-c214fb649e3e.png)

![image](https://user-images.githubusercontent.com/43224250/195431887-a1e97c9c-3de8-4780-a0e9-db007b8a4f0d.png)
