### PR TITLE
Feature / List comments endpoint

### DIFF
--- a/apps/laravel/app/app/Exceptions/CustomExceptionHandler.php
+++ b/apps/laravel/app/app/Exceptions/CustomExceptionHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Http\Response;
+
+class CustomExceptionHandler
+{
+    public static function handleException(\Exception $e): void {
+        if(env('APP_DEBUG', false)) {
+            abort(Response::HTTP_UNPROCESSABLE_ENTITY, $e->getMessage());
+        }
+
+        abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'Unprocessable entity');
+    }
+}

--- a/apps/laravel/app/app/Http/Transformers/CommentTransformer.php
+++ b/apps/laravel/app/app/Http/Transformers/CommentTransformer.php
@@ -6,14 +6,50 @@ use App\Transformers\AbstractTransFormer;
 
 class CommentTransformer extends AbstractTransFormer
 {
+    function __construct() {}
 
     /**
-     * @param array $input: Comment[]
+     * @param array $comments
      * @return array
      */
-    public function transform(array $input): array
+    public function transform(array $comments): array
     {
-        // @TODO
-        return $input;
+        $output = [];
+        foreach($comments as $comment) {
+            if (!$comment->parent_id)
+                array_push($output, [
+                    "id" => $comment->id,
+                    "name" => $comment->name,
+                    "message" => $comment->message,
+                    "comments" => $this->transformSubComments($comment->id, $comments),
+                ]);
+        }
+        return $output;
+    }
+
+    /**
+     * @param int $parentCommentId
+     * @param array $comments
+     * @return array
+     */
+    private function transformSubComments(
+        int $parentCommentId,
+        array $comments
+    ): array {
+        $output = [];
+        $filteredComments = array_filter($comments,
+            function ($comment) use ($parentCommentId) {
+                return $comment->parent_id == $parentCommentId;
+            });
+
+        foreach($filteredComments as $comment) {
+            array_push($output, [
+                "id" => $comment->id,
+                "name" => $comment->name,
+                "message" => $comment->message,
+                "comments" => $this->transformSubComments($comment->id, $comments),
+            ]);
+        }
+        return $output;
     }
 }

--- a/apps/laravel/app/app/Services/Comment/CommentService.php
+++ b/apps/laravel/app/app/Services/Comment/CommentService.php
@@ -2,8 +2,9 @@
 
 namespace App\Services\Comment;
 
-use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Illuminate\Support\Facades\DB;
+use App\Exceptions\CustomExceptionHandler;
 
 /**
  * Class CommentService
@@ -11,16 +12,20 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  */
 class CommentService
 {
-    public function getByPostId(int $postId): void
+    /**
+     * @param int $postId
+     * @return array
+    */
+    public function getByPostId(int $postId): array
     {
         try {
-            // @TODO
+            return DB::select("SELECT * from comments WHERE post_id = $postId");
         }
         catch(HttpException $e) {
             abort($e->getStatusCode(), $e->getMessage());
         }
         catch(\Exception $e) {
-            $this->handleException($e);
+            CustomExceptionHandler::handleException($e);
         }
     }
 
@@ -33,7 +38,7 @@ class CommentService
             abort($e->getStatusCode(), $e->getMessage());
         }
         catch(\Exception $e) {
-            $this->handleException($e);
+            CustomExceptionHandler::handleException($e);
         }
     }
 
@@ -50,7 +55,7 @@ class CommentService
             abort($e->getStatusCode(), $e->getMessage());
         }
         catch(\Exception $e) {
-            $this->handleException($e);
+            CustomExceptionHandler::handleException($e);
         }
     }
 
@@ -63,16 +68,7 @@ class CommentService
             abort($e->getStatusCode(), $e->getMessage());
         }
         catch(\Exception $e) {
-            $this->handleException($e);
+            CustomExceptionHandler::handleException($e);
         }
     }
-
-    private function handleException(\Exception $e): void {
-        if(env('APP_DEBUG', false)) {
-            abort(Response::HTTP_UNPROCESSABLE_ENTITY, $e->getMessage());
-        }
-
-        abort(Response::HTTP_UNPROCESSABLE_ENTITY, 'Unprocessable entity');
-    }
-
 }


### PR DESCRIPTION
## Description

Hi.

This PR brings up an endpoint when called is able to bring all comments associated with a blog post. Also, I decided to return all comments on every api calls instead status 204 (no content). This decision makes easier to create integration tests.

### Todos
That `CommentTransformer` deserves a Unit test, so it's a must later.

### CustomExceptionHandler
I found important to create a `CustomExceptionHandler` under `App/Exceptions` because I needed to reuse that functionality on that `CommentController`. I did that because I believe we wouldn't like to expose an error to the world in case the transform fail for some unknown reason.

## Screenshots

![image](https://user-images.githubusercontent.com/43224250/195467686-a693b5dd-82a9-41c9-81bf-e66ca59dab0d.png)

