### PR TITLE
Feature / Comment insertion

### DIFF
--- a/apps/laravel/app/app/Services/Comment/CommentService.php
+++ b/apps/laravel/app/app/Services/Comment/CommentService.php
@@ -2,9 +2,11 @@
 
 namespace App\Services\Comment;
 
+use Illuminate\Http\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Support\Facades\DB;
 use App\Exceptions\CustomExceptionHandler;
+use Carbon\Carbon;
 
 /**
  * Class CommentService
@@ -29,10 +31,34 @@ class CommentService
         }
     }
 
+    /**
+     * @param int $postId
+     * @param array $data
+     * @return array
+    */
     public function save(int $postId, array $data): void
     {
         try {
-            // @TODO
+            if(
+                isset($data['parentId']) &&
+                !$this->allowedToComment($postId, $data['parentId'])
+            ) {
+                abort(
+                    Response::HTTP_UNPROCESSABLE_ENTITY,
+                    'Sub-comments are up to the 3rd layer only (3 layers from the root comment)'
+                );
+            }
+
+            $insertData = [
+                'post_id' => $postId,
+                'parent_id' => isset($data['parentId']) ? $data['parentId'] : null,
+                'name' => $data['name'],
+                'message' => $data['message'],
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now()
+            ];
+
+            DB::table('comments')->insert($insertData);
         }
         catch(HttpException $e) {
             abort($e->getStatusCode(), $e->getMessage());
@@ -70,5 +96,26 @@ class CommentService
         catch(\Exception $e) {
             CustomExceptionHandler::handleException($e);
         }
+    }
+
+    private function allowedToComment($postId, $parentId) {
+        $allowed = DB::select("
+            SELECT
+                c1.parent_id as 'c1_parent_id',
+                c2.parent_id as 'c2_parent_id'
+            FROM comments c2
+            LEFT JOIN comments c1 on c1.id = c2.parent_id
+            WHERE
+                c2.post_id = $postId AND
+                c2.id = $parentId
+                limit 1;
+        ");
+
+        if(
+            count($allowed) > 0 &&
+            $allowed[0]->c1_parent_id &&
+            $allowed[0]->c2_parent_id
+        ) return false;
+        return true;
     }
 }

--- a/apps/laravel/app/database/seeders/DatabaseSeeder.php
+++ b/apps/laravel/app/database/seeders/DatabaseSeeder.php
@@ -17,30 +17,49 @@ class DatabaseSeeder extends Seeder
         $this->runCommentsTableSeeder();
     }
 
-    // @TODO - it doesn't look good, i'll later improve later by breaking those long lines
     private function runCommentsTableSeeder() {
         // First root comment tree
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, null, 'andre', 'main message', '2022-10-12 00:00:00', '2022-10-12 00:00:00')"); // # 1 (main)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, null, 'andre', 'main message', '2022-10-12 00:00:00', '2022-10-12 00:00:00')");
 
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 1, 'andre-sub', 'sub message 1', '2022-10-12 00:00:05', '2022-10-12 00:00:05')"); // # 2 (sub)
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 1, 'andre-sub', 'sub message 2', '2022-10-12 00:00:10', '2022-10-12 00:00:10')"); // # 3 (sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 1, 'andre-sub', 'sub message 1', '2022-10-12 00:00:05', '2022-10-12 00:00:05')");
 
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 2, 'andre-sub-sub', 'sub-sub message 1', '2022-10-12 00:00:15', '2022-10-12 00:00:15');"); // # 4 (sub-sub)
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 2, 'andre-sub-sub', 'sub-sub message 2', '2022-10-12 00:00:20', '2022-10-12 00:00:20');"); // # 5 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 1, 'andre-sub', 'sub message 2', '2022-10-12 00:00:10', '2022-10-12 00:00:10')");
 
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 3, 'andre-sub-sub', 'sub-sub message 3', '2022-10-12 00:00:25', '2022-10-12 00:00:25');"); // # 6 (sub-sub)
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 3, 'andre-sub-sub', 'sub-sub message 4', '2022-10-12 00:00:30', '2022-10-12 00:00:30');"); // # 7 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 2, 'andre-sub-sub', 'sub-sub message 1', '2022-10-12 00:00:15', '2022-10-12 00:00:15');");
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 2, 'andre-sub-sub', 'sub-sub message 2', '2022-10-12 00:00:20', '2022-10-12 00:00:20');");
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 3, 'andre-sub-sub', 'sub-sub message 3', '2022-10-12 00:00:25', '2022-10-12 00:00:25');");
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 3, 'andre-sub-sub', 'sub-sub message 4', '2022-10-12 00:00:30', '2022-10-12 00:00:30');");
 
         // Second root comment tree
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, null, 'maxim', 'main message', '2022-10-12 00:00:32', '2022-10-12 00:00:32')"); // # 8 (main)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, null, 'maxim', 'main message', '2022-10-12 00:00:32', '2022-10-12 00:00:32')");
 
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 8, 'maxim-sub', 'sub message 1', '2022-10-12 00:00:35', '2022-10-12 00:00:35')"); // # 9 (sub)
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 8, 'maxim-sub', 'sub message 2', '2022-10-12 00:00:40', '2022-10-12 00:00:40')"); // # 10 (sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 8, 'maxim-sub', 'sub message 1', '2022-10-12 00:00:35', '2022-10-12 00:00:35')");
 
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 9, 'maxim-sub-sub', 'sub-sub message 1', '2022-10-12 00:00:45', '2022-10-12 00:00:45');"); // # 11 (sub-sub)
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 9, 'maxim-sub-sub', 'sub-sub message 2', '2022-10-12 00:00:50', '2022-10-12 00:00:50');"); // # 12 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 8, 'maxim-sub', 'sub message 2', '2022-10-12 00:00:40', '2022-10-12 00:00:40')");
 
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 10, 'maxim-sub-sub', 'sub-sub message 3', '2022-10-12 00:00:55', '2022-10-12 00:00:55');"); // # 13 (sub-sub)
-        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at) values(1, 10, 'maxim-sub-sub', 'sub-sub message 4', '2022-10-12 00:00:58', '2022-10-12 00:00:58');"); // # 14 (sub-sub)
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 9, 'maxim-sub-sub', 'sub-sub message 1', '2022-10-12 00:00:45', '2022-10-12 00:00:45');");
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 9, 'maxim-sub-sub', 'sub-sub message 2', '2022-10-12 00:00:50', '2022-10-12 00:00:50');");
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 10, 'maxim-sub-sub', 'sub-sub message 3', '2022-10-12 00:00:55', '2022-10-12 00:00:55');");
+
+        DB::insert("INSERT INTO comments (post_id, parent_id, name, message, created_at, updated_at)
+            values(1, 10, 'maxim-sub-sub', 'sub-sub message 4', '2022-10-12 00:00:58', '2022-10-12 00:00:58');");
     }
 }


### PR DESCRIPTION
## Description

Hi.

This PR brings up the the comment insertion endpoint fully functional. I decided to polish the `DatabaseSeeder` file since I left a `@TODO` there earlier.

The logic to figure out if the user is able or not to make a comment is pretty simple, I created a left join from second layer comments to first layer comments, and the if parent_id in both layers are not nulled, then the user is already on the 3rd layer and it won't be able to make nested comment.

## Screenshots

![image](https://user-images.githubusercontent.com/43224250/195479037-8c47714f-9819-4cb4-84b3-a92e2e7e3d17.png)

