### PR TITLE
Fix / Ability to create nested comment on unexisting parent comment

### DIFF
--- a/apps/laravel/app/app/Http/Controllers/CommentController.php
+++ b/apps/laravel/app/app/Http/Controllers/CommentController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
 use App\Http\Requests\Comment\StoreCommentRequest;
 use App\Http\Requests\Comment\UpdateCommentRequest;
 use App\Http\Transformers\CommentTransformer;
@@ -25,6 +27,9 @@ class CommentController extends Controller
                 $this->getAllCommentsByPostId($service, $postId)
             );
         }
+        catch(HttpException $e) {
+            abort($e->getStatusCode(), $e->getMessage());
+        }
         catch(\Exception $e) {
             CustomExceptionHandler::handleException($e);
         }
@@ -41,6 +46,9 @@ class CommentController extends Controller
             return $this->response->array(
                 $this->getAllCommentsByPostId($service, $postId)
             )->setStatusCode(201);
+        }
+        catch(HttpException $e) {
+            abort($e->getStatusCode(), $e->getMessage());
         }
         catch(\Exception $e) {
             CustomExceptionHandler::handleException($e);
@@ -60,6 +68,9 @@ class CommentController extends Controller
                 $this->getAllCommentsByPostId($service, $postId)
             );
         }
+        catch(HttpException $e) {
+            abort($e->getStatusCode(), $e->getMessage());
+        }
         catch(\Exception $e) {
             CustomExceptionHandler::handleException($e);
         }
@@ -76,6 +87,9 @@ class CommentController extends Controller
                 $this->getAllCommentsByPostId($service, $postId)
             );
         }
+        catch(HttpException $e) {
+            abort($e->getStatusCode(), $e->getMessage());
+        }
         catch(\Exception $e) {
             CustomExceptionHandler::handleException($e);
         }
@@ -85,9 +99,12 @@ class CommentController extends Controller
         CommentService $service,
         int $postId
     ): array {
-        $comments = $service->getByPostId($postId);
         try {
+            $comments = $service->getByPostId($postId);
             return (new CommentTransformer)->transform($comments);
+        }
+        catch(HttpException $e) {
+            abort($e->getStatusCode(), $e->getMessage());
         }
         catch(\Exception $e) {
             CustomExceptionHandler::handleException($e);

--- a/apps/laravel/app/app/Services/Comment/CommentService.php
+++ b/apps/laravel/app/app/Services/Comment/CommentService.php
@@ -41,6 +41,11 @@ class CommentService
     public function save(int $postId, array $data): void
     {
         try {
+
+            if(isset($data['parentId'])) {
+                $this->checkIfParentCommentExists($data['parentId']);
+            }
+
             if (
                 isset($data['parentId']) &&
                 !$this->allowedToComment($postId, $data['parentId'])
@@ -154,5 +159,21 @@ class CommentService
         ");
 
         return CommentHelper::isThirdLayerSubComment($dbOutput);
+    }
+
+    /**
+     * @param int $postId
+     * @param int $commentId
+     * @return bool
+    */
+    private function checkIfParentCommentExists($parentId): void {
+        $rows = DB::table('comments')->where('id', $parentId)->count('id');
+
+        if ($rows == 0) {
+            abort(
+                Response::HTTP_NOT_FOUND,
+                'Parent comment does not exists'
+            );
+        }
     }
 }

--- a/apps/laravel/app/tests/Feature/CommentTest.php
+++ b/apps/laravel/app/tests/Feature/CommentTest.php
@@ -54,6 +54,23 @@ class CommentTest extends TestCase
      * @test
      * @return void
      */
+    public function create_comment_endpoint_fails_due_unexisting_parent_comment()
+    {
+        $response = $this->postJson(
+            '/api/blog-post/1/comment',
+            [
+                "parentId" => 99,
+                "name" => "test",
+                "message" => "message-test",
+            ]
+        );
+        $response->assertStatus(404);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
     public function create_first_layer_comment_gives_created_response()
     {
         $response = $this->postJson(


### PR DESCRIPTION
## Description

Hi.

The whole app was submitted to QA team, and they reported that the comment creation endpoint was not behaving as expected. It was allowing users to create nested comments using an unexisting parent comment.

The problem was fixed, and to cover the situation I decided to create a new feature test.

## Screenshots

![image](https://user-images.githubusercontent.com/43224250/195501324-46a597d5-cd3c-45b8-bbaa-63c5c564c999.png)
